### PR TITLE
access.log path from environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Add env var for access.log (#41)
+
 ## [V0.5.0] - 2020-03-09
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vroom-express",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "An express server to expose VROOM as a web API.",
   "scripts": {
     "test": "npm run-script test:other && npm run-script test:js",

--- a/src/config.js
+++ b/src/config.js
@@ -15,7 +15,7 @@ try {
 
 // Prefer env variable for router & access.log
 const router = process.env.VROOM_ROUTER || config_yml.cliArgs.router;
-const logdir = process.env.VROOM_LOG || config_yml.cliArgs.logdir;
+const logdir = process.env.VROOM_LOG || __dirname + config_yml.cliArgs.logdir;
 
 // Config variables.
 const cliArgs = minimist(process.argv.slice(2), {
@@ -27,7 +27,7 @@ const cliArgs = minimist(process.argv.slice(2), {
   default: {
     geometry: config_yml.cliArgs.geometry, // retrieve geometry (-g)
     limit: config_yml.cliArgs.limit, // max request size
-    logdir: __dirname + logdir, // put logs in there
+    logdir: logdir, // put logs in there
     maxlocations: config_yml.cliArgs.maxlocations, // max number of jobs/shipments locations
     maxvehicles: config_yml.cliArgs.maxvehicles, // max number of vehicles
     override: config_yml.cliArgs.override, // allow cl option override (-g only so far)

--- a/src/config.js
+++ b/src/config.js
@@ -13,8 +13,9 @@ try {
   process.exit();
 }
 
-// Prefer env variable for router
+// Prefer env variable for router & access.log
 const router = process.env.VROOM_ROUTER || config_yml.cliArgs.router;
+const logdir = process.env.VROOM_LOG || config_yml.cliArgs.logdir;
 
 // Config variables.
 const cliArgs = minimist(process.argv.slice(2), {
@@ -26,7 +27,7 @@ const cliArgs = minimist(process.argv.slice(2), {
   default: {
     geometry: config_yml.cliArgs.geometry, // retrieve geometry (-g)
     limit: config_yml.cliArgs.limit, // max request size
-    logdir: __dirname + config_yml.cliArgs.logdir, // put logs in there
+    logdir: __dirname + logdir, // put logs in there
     maxlocations: config_yml.cliArgs.maxlocations, // max number of jobs/shipments locations
     maxvehicles: config_yml.cliArgs.maxvehicles, // max number of vehicles
     override: config_yml.cliArgs.override, // allow cl option override (-g only so far)


### PR DESCRIPTION
The path to the access.log server logging file will be preferred as environment variable VROOM_LOG and can additionally be set in `config.yml` as before. Mostly helping in https://github.com/VROOM-Project/vroom-docker/issues/2. 