### PR TITLE
Dependencies cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Update dependencies (#63)
+
 ### Removed
 
 - Drop `body-parser` dependency (#62)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Removed
+
+- Drop `body-parser` dependency (#62)
+
 ## [v0.7.0] - 2020-07-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
   "license": "BSD-2-Clause",
   "dependencies": {
     "express": "^4.17.1",
-    "helmet": "^3.22.0",
-    "js-yaml": "^3.13.1",
+    "helmet": "^3.23.3",
+    "js-yaml": "^3.14.1",
     "minimist": "^1.2.5",
     "morgan": "^1.10.0",
-    "uuid": "^8.0.0"
+    "uuid": "^8.3.2"
   },
   "repository": {
     "type": "git",
@@ -41,7 +41,7 @@
   "devDependencies": {
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^4.3.0",
-    "eslint-plugin-prettier": "^3.1.3",
+    "eslint-plugin-prettier": "^3.2.0",
     "husky": "^2.7.0",
     "lint-staged": "^8.2.1",
     "prettier": "^1.19.1"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "author": "Julien Coupey",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "body-parser": "^1.19.0",
     "express": "^4.17.1",
     "helmet": "^3.22.0",
     "js-yaml": "^3.13.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "license": "BSD-2-Clause",
   "dependencies": {
     "express": "^4.17.1",
-    "helmet": "^3.23.3",
+    "helmet": "^4.2.0",
     "js-yaml": "^3.14.1",
     "minimist": "^1.2.5",
     "morgan": "^1.10.0",
@@ -39,10 +39,10 @@
     "url": "https://github.com/VROOM-Project/vroom-express.git"
   },
   "devDependencies": {
-    "eslint": "^6.8.0",
-    "eslint-config-prettier": "^4.3.0",
+    "eslint": "^7.15.0",
+    "eslint-config-prettier": "^7.0.0",
     "eslint-plugin-prettier": "^3.2.0",
-    "husky": "^2.7.0",
+    "husky": "^3.1.0",
     "lint-staged": "^8.2.1",
     "prettier": "^1.19.1"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-const bodyParser = require('body-parser');
 const express = require('express');
 const fs = require('fs');
 const helmet = require('helmet');
@@ -26,8 +25,8 @@ app.use((req, res, next) => {
 });
 
 const args = config.cliArgs;
-app.use(bodyParser.json({limit: args.limit}));
-app.use(bodyParser.urlencoded({extended: true, limit: args.limit}));
+app.use(express.json({limit: args.limit}));
+app.use(express.urlencoded({extended: true, limit: args.limit}));
 
 const accessLogStream = fs.createWriteStream(args.logdir + '/access.log', {
   flags: 'a'


### PR DESCRIPTION
Fixes #62, fixes #63.

For the record:

- updating `husky` to the `4.*` series would require node 10 so I stick with a major update to `3.1.0`;
- updating `prettier` to `2.2.1` resulted in pre-comit hook errors. Those seemed related to dependencies, not our actual codebase, so I lazily did not update `prettier`.