### PR TITLE
Possibility to pass -c parameter in options like -g, -x, -t (ETA Mode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v0.9.0] - 2021-04-13
+
+### Added
+
+- Possibility to launch VROOM in plan mode using -c flag as parameter. (#70, #71)
+
 ## [v0.8.0] - 2021-03-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Optionally set `VROOM_ROUTER=<router>`, `router` being `osrm` (default), `libosr
 
 ## Client side
 
-If `override` is set to `true` in `config.yml`, then the `vroom` command-line parameters `-g`, `-c`, `-t` and `-x` can be set dynamically per request in order to add detailed route geometry and indicators, run vroom in ETA mode, set the number of threads and exploration level.
+If `override` is set to `true` in `config.yml`, then the `vroom` command-line parameters `-g`, `-c`, `-t` and `-x` can be set dynamically per request in order to add detailed route geometry and indicators, run vroom in plan mode, set the number of threads and exploration level.
 
 Set values in the json payload via the `options` key:
 

--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,6 @@
 cliArgs:
   geometry: false # retrieve geometry (-g)
-  etamode: false # run vroom in ETA mode (-c) if set to true
+  planmode: false # run vroom in plan mode (-c) if set to true
   threads: 4 # number of threads to use (-t)
   explore: 5 # exploration level to use (0..5) (-x)
   limit: '1mb' # max request size
@@ -8,7 +8,7 @@ cliArgs:
   logsize: '100M' # max log file size for rotation
   maxlocations: 1000 # max number of jobs/shipments locations
   maxvehicles: 200 # max number of vehicles
-  override: true # allow cli options override (-g, -t and -x)
+  override: true # allow cli options override (-c, -g, -t and -x)
   path: '' # VROOM path (if not in $PATH)
   port: 3000 # expressjs port
   router: 'osrm' # routing backend (osrm, libosrm or ors)

--- a/src/config.js
+++ b/src/config.js
@@ -31,7 +31,6 @@ const cliArgs = minimist(process.argv.slice(2), {
   boolean: ['geometry', 'override'],
   default: {
     baseurl: baseurl, // base root url for api.
-    etamode: config_yml.cliArgs.etamode, // retrieve ETA mode config (-c)
     explore: config_yml.cliArgs.explore, // exploration level to use (0..5) (-x)
     geometry: config_yml.cliArgs.geometry, // retrieve geometry (-g)
     limit: config_yml.cliArgs.limit, // max request size
@@ -41,6 +40,7 @@ const cliArgs = minimist(process.argv.slice(2), {
     maxvehicles: config_yml.cliArgs.maxvehicles, // max number of vehicles
     override: config_yml.cliArgs.override, // allow cl option override (-g only so far)
     path: config_yml.cliArgs.path, // VROOM path (if not in $PATH)
+    planmode: config_yml.cliArgs.planmode, // retrieve plan mode config (-c)
     port: config_yml.cliArgs.port, // expressjs port
     router: router, // routing backend (osrm, libosrm or ors)
     threads: config_yml.cliArgs.threads, // number of threads to use (-t)

--- a/src/index.js
+++ b/src/index.js
@@ -171,7 +171,7 @@ const execCallback = function(req, res) {
     reqOptions.push('-g');
   }
 
-  // ETA Mode Retrieving
+  // Plan mode Retrieving
   if (
     args.override &&
     'options' in req.body &&


### PR DESCRIPTION
violations are now sent in response so it seems to work but time_windows are not convert into soft constraints. 
I will open an Issues