### PR TITLE
Added C# API client link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ See the
 [API documentation](https://github.com/VROOM-Project/vroom/blob/master/docs/API.md)
 for input syntax.
 
+## API Clients
+
+Members of the community have created some unofficial API clients:
+|Language|Link                                   |
+|--------|---------------------------------------|
+|C#      |https://github.com/calebfaith/vroom.net|
+
 # Customization
 
 ## Server side


### PR DESCRIPTION
Hey,
I created a C# API client for use with my personal project. If possible, I would like to share it with the community by adding a link to it in your readme. Let me know if you would like the position in the readme or the wording to be changed, I don't mind!