### PR TITLE
refactor!: adjust ors hosts in config to contain default path /ors/v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- ors hosts in config to contain default base path /ors/v2 ([#99](https://github.com/VROOM-Project/vroom-express/pull/99)) 
+
 ## [v0.11.0] - 2022-06-11
 
 ### Added

--- a/config.yml
+++ b/config.yml
@@ -27,28 +27,28 @@ routingServers:
       port: '5002'
   ors:
     driving-car:
-      host: '0.0.0.0'
+      host: '0.0.0.0/ors/v2'
       port: '8080'
     driving-hgv:
-      host: '0.0.0.0'
+      host: '0.0.0.0/ors/v2'
       port: '8080'
     cycling-regular:
-      host: '0.0.0.0'
+      host: '0.0.0.0/ors/v2'
       port: '8080'
     cycling-mountain:
-      host: '0.0.0.0'
+      host: '0.0.0.0/ors/v2'
       port: '8080'
     cycling-road:
-      host: '0.0.0.0'
+      host: '0.0.0.0/ors/v2'
       port: '8080'
     cycling-electric:
-      host: '0.0.0.0'
+      host: '0.0.0.0/ors/v2'
       port: '8080'
     foot-walking:
-      host: '0.0.0.0'
+      host: '0.0.0.0/ors/v2'
       port: '8080'
     foot-hiking:
-      host: '0.0.0.0'
+      host: '0.0.0.0/ors/v2'
       port: '8080'
   valhalla:
     auto:


### PR DESCRIPTION
BREAKING-CHANGE: this adjusts to the removal of the hard-coded ors base path in vroom
  see https://github.com/VROOM-Project/vroom/pull/1037