### PR TITLE
feat: add solvelimit to config.yaml, matching timeout value

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -3,6 +3,7 @@ cliArgs:
   planmode: false # run vroom in plan mode (-c) if set to true
   threads: 4 # number of threads to use (-t)
   explore: 5 # exploration level to use (0..5) (-x)
+  solvelimit: 300 # stop solving process after 'limit' seconds (-l)
   limit: '1mb' # max request size
   logdir: '/..' # the path for the logs relative to ./src
   logsize: '100M' # max log file size for rotation

--- a/src/config.js
+++ b/src/config.js
@@ -32,6 +32,7 @@ const cliArgs = minimist(process.argv.slice(2), {
   default: {
     baseurl: baseurl, // base root url for api.
     explore: config_yml.cliArgs.explore, // exploration level to use (0..5) (-x)
+    solvelimit: config_yml.cliArgs.solvelimit, // stop solving process after 'limit' seconds (-l)
     geometry: config_yml.cliArgs.geometry, // retrieve geometry (-g)
     limit: config_yml.cliArgs.limit, // max request size
     logdir: logdir, // put logs in there

--- a/src/index.js
+++ b/src/index.js
@@ -165,6 +165,7 @@ function execCallback(req, res) {
   // Default command-line values.
   let nbThreads = args.threads;
   let explorationLevel = args.explore;
+  let solveLimit = args.solveLimit;
 
   if (args.override && 'options' in req.body) {
     // Optionally override defaults.
@@ -190,12 +191,13 @@ function execCallback(req, res) {
     }
 
     if ('l' in req.body.options && typeof req.body.options.l == 'number') {
-      reqOptions.push('-l ' + req.body.options.l);
+      solveLimit = req.body.options.l;
     }
   }
 
   reqOptions.push('-t ' + nbThreads);
   reqOptions.push('-x ' + explorationLevel);
+  reqOptions.push('-l ' + solveLimit);
 
   const timestamp = Math.floor(Date.now() / 1000); //eslint-disable-line
   const fileName = args.logdir + '/' + timestamp + '_' + uuid.v1() + '.json';


### PR DESCRIPTION
This PR introduces the ability to set the solvelimit parameter in config.yaml for VROOM-Express. The proposed value matches the default VROOM timeout, allowing the time limit to be configured globally instead of being specified in each request.

Changes:
- Added solvelimit parameter to config.yaml.
- The value of solvelimit is set to match the default VROOM timeout.

Benefits:
- Streamlines configuration by enabling users to set the time limit once in config.yaml.
- Eliminates the need to include the time limit option in each request to VROOM.
- Ensures consistent behavior with VROOM's default timeout settings.