### PR TITLE
Allow overriding options individually and setting g/c option to false

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -4,7 +4,7 @@ cliArgs:
   threads: 4 # number of threads to use (-t)
   explore: 5 # exploration level to use (0..5) (-x)
   limit: '1mb' # max request size
-  logdir: '/..' # the path for the logs relative to ./src
+  logdir: '..' # the path for the logs relative to ./src
   logsize: '100M' # max log file size for rotation
   maxlocations: 1000 # max number of jobs/shipments locations
   maxvehicles: 200 # max number of vehicles

--- a/config.yml
+++ b/config.yml
@@ -8,7 +8,7 @@ cliArgs:
   logsize: '100M' # max log file size for rotation
   maxlocations: 1000 # max number of jobs/shipments locations
   maxvehicles: 200 # max number of vehicles
-  override: true # allow cli options override (-c, -g, -l, -t, and -x)
+  override: ['c', 'g', 'l', 't', 'x'] # allow cli options override (c, g, l, t, and x)
   path: '' # VROOM path (if not in $PATH)
   port: 3000 # expressjs port
   router: 'osrm' # routing backend (osrm, libosrm, ors, or valhalla)

--- a/src/config.js
+++ b/src/config.js
@@ -27,10 +27,11 @@ if (baseurl.substr(-1) !== '/') {
 // Config variables.
 const cliArgs = minimist(process.argv.slice(2), {
   alias: {
+    o: 'override', // eslint-disable-line
     p: 'port', // eslint-disable-line
     r: 'router', // eslint-disable-line
   },
-  boolean: ['geometry', 'override'],
+  boolean: ['geometry'],
   default: {
     baseurl: baseurl, // base root url for api.
     explore: config_yml.cliArgs.explore, // exploration level to use (0..5) (-x)
@@ -40,15 +41,19 @@ const cliArgs = minimist(process.argv.slice(2), {
     logsize: config_yml.cliArgs.logsize, // max log file size for rotation
     maxlocations: config_yml.cliArgs.maxlocations, // max number of jobs/shipments locations
     maxvehicles: config_yml.cliArgs.maxvehicles, // max number of vehicles
-    override: config_yml.cliArgs.override, // allow cl option override (-g only so far)
+    override: config_yml.cliArgs.override, // allow cl option override
     path: config_yml.cliArgs.path, // VROOM path (if not in $PATH)
     planmode: config_yml.cliArgs.planmode, // set plan mode (-c)
     port: config_yml.cliArgs.port, // expressjs port
-    router: router, // routing backend (osrm, libosrm or ors)
+    router: router, // routing backend
     threads: config_yml.cliArgs.threads, // number of threads to use (-t)
     timeout: config_yml.cliArgs.timeout, // milli-seconds.
   },
 });
+// Convert override option to array if it was provided just once
+if (typeof cliArgs.override === 'string') {
+  cliArgs.override = [cliArgs.override];
+}
 
 // Error codes
 const VROOM_OK_CODE = 0;

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,7 @@
 const minimist = require('minimist');
 const yaml = require('js-yaml');
 const fs = require('fs');
+const path = require('path');
 
 let config_yml;
 try {
@@ -15,7 +16,8 @@ try {
 
 // Prefer env variable for router & access.log
 const router = process.env.VROOM_ROUTER || config_yml.cliArgs.router;
-const logdir = process.env.VROOM_LOG || __dirname + config_yml.cliArgs.logdir;
+const logdir =
+  process.env.VROOM_LOG || path.join(__dirname, config_yml.cliArgs.logdir);
 
 let baseurl = config_yml.cliArgs.baseurl;
 if (baseurl.substr(-1) !== '/') {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const { spawn } = require('child_process');
+const {spawn} = require('child_process');
 const express = require('express');
 const fs = require('fs');
 const helmet = require('helmet');
@@ -60,7 +60,7 @@ app.use((err, req, res, next) => {
 function now() {
   const date = new Date();
   return date.toUTCString();
-};
+}
 
 function fileExists(filePath) {
   try {
@@ -68,7 +68,7 @@ function fileExists(filePath) {
   } catch (err) {
     return false;
   }
-};
+}
 
 // Callback for size and some input validity checks.
 function sizeCheckCallback(maxLocationNumber, maxVehicleNumber) {
@@ -130,7 +130,7 @@ function sizeCheckCallback(maxLocationNumber, maxVehicleNumber) {
     }
     next();
   };
-};
+}
 
 const vroomCommand = args.path + 'vroom';
 const options = [];
@@ -271,7 +271,7 @@ function execCallback(req, res) {
       fs.unlinkSync(fileName);
     }
   });
-};
+}
 
 app.post(args.baseurl, [
   sizeCheckCallback(args.maxlocations, args.maxvehicles),

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ const morgan = require('morgan');
 const uuid = require('uuid');
 const config = require('./config.js');
 const rfs = require('rotating-file-stream');
+const path = require('path');
 
 // App and loaded modules.
 const app = express();
@@ -30,7 +31,7 @@ const args = config.cliArgs;
 app.use(express.json({limit: args.limit}));
 app.use(express.urlencoded({extended: true, limit: args.limit}));
 
-const accessLogStream = rfs.createStream(args.logdir + '/access.log', {
+const accessLogStream = rfs.createStream(path.join(args.logdir, 'access.log'), {
   compress: 'gzip',
   size: args.logsize,
 });
@@ -132,7 +133,7 @@ function sizeCheckCallback(maxLocationNumber, maxVehicleNumber) {
   };
 }
 
-const vroomCommand = args.path + 'vroom';
+const vroomCommand = path.join(args.path, 'vroom');
 const options = [];
 options.push('-r', args.router);
 if (args.router !== 'libosrm') {
@@ -190,15 +191,18 @@ function execCallback(req, res) {
     }
 
     if ('l' in req.body.options && typeof req.body.options.l == 'number') {
-      reqOptions.push('-l ' + req.body.options.l);
+      reqOptions.push('-l', req.body.options.l);
     }
   }
 
-  reqOptions.push('-t ' + nbThreads);
-  reqOptions.push('-x ' + explorationLevel);
+  reqOptions.push('-t', nbThreads);
+  reqOptions.push('-x', explorationLevel);
 
   const timestamp = Math.floor(Date.now() / 1000); //eslint-disable-line
-  const fileName = args.logdir + '/' + timestamp + '_' + uuid.v1() + '.json';
+  const fileName = path.join(
+    args.logdir,
+    timestamp + '_' + uuid.v1() + '.json'
+  );
   try {
     fs.writeFileSync(fileName, JSON.stringify(req.body));
   } catch (err) {
@@ -212,7 +216,7 @@ function execCallback(req, res) {
     return;
   }
 
-  reqOptions.push('-i ' + fileName);
+  reqOptions.push('-i', '"' + fileName + '"');
 
   const vroom = spawn(vroomCommand, reqOptions, {shell: true});
 

--- a/src/index.js
+++ b/src/index.js
@@ -134,15 +134,15 @@ function sizeCheckCallback(maxLocationNumber, maxVehicleNumber) {
 }
 
 const vroomCommand = path.join(args.path, 'vroom');
-const options = [];
-options.push('-r', args.router);
+const defaultOptions = [];
+defaultOptions.push('-r', args.router);
 if (args.router !== 'libosrm') {
   const routingServers = config.routingServers;
   for (const profileName in routingServers[args.router]) {
     const profile = routingServers[args.router][profileName];
     if ('host' in profile && 'port' in profile) {
-      options.push('-a', profileName + ':' + profile.host);
-      options.push('-p', profileName + ':' + profile.port);
+      defaultOptions.push('-a', profileName + ':' + profile.host);
+      defaultOptions.push('-p', profileName + ':' + profile.port);
     } else {
       console.error(
         "Incomplete configuration: profile '" +
@@ -152,51 +152,68 @@ if (args.router !== 'libosrm') {
     }
   }
 }
-if (args.geometry) {
-  options.push('-g');
-}
 
-if (args.planmode) {
-  options.push('-c');
+if (args.override === true) {
+  args.override = ['c', 'g', 'l', 't', 'x'];
 }
+const allowedOverrides = new Set(
+  Array.isArray(args.override) ? args.override : []
+);
 
 function execCallback(req, res) {
-  const reqOptions = options.slice();
+  const options = defaultOptions.slice();
 
   // Default command-line values.
+  let planMode = args.planmode;
+  let geometry = args.geometry;
   let nbThreads = args.threads;
   let explorationLevel = args.explore;
 
-  if (args.override && 'options' in req.body) {
+  const reqOptions = req.body.options;
+  if (reqOptions) {
     // Optionally override defaults.
 
     // Retrieve route geometry.
-    if (!args.geometry && 'g' in req.body.options && req.body.options.g) {
-      reqOptions.push('-g');
+    if (
+      allowedOverrides.has('g') &&
+      'g' in reqOptions &&
+      reqOptions.g !== null
+    ) {
+      geometry = Boolean(reqOptions.g);
     }
 
     // Set plan mode.
-    if (!args.planmode && 'c' in req.body.options && req.body.options.c) {
-      reqOptions.push('-c');
+    if (
+      allowedOverrides.has('c') &&
+      'c' in reqOptions &&
+      reqOptions.c !== null
+    ) {
+      planMode = Boolean(reqOptions.c);
     }
 
     // Adjust number of threads.
-    if ('t' in req.body.options && typeof req.body.options.t == 'number') {
-      nbThreads = req.body.options.t;
+    if (allowedOverrides.has('t') && typeof reqOptions.t === 'number') {
+      nbThreads = reqOptions.t;
     }
 
     // Adjust exploration level.
-    if ('x' in req.body.options && typeof req.body.options.x == 'number') {
-      explorationLevel = req.body.options.x;
+    if (allowedOverrides.has('x') && typeof reqOptions.x === 'number') {
+      explorationLevel = reqOptions.x;
     }
 
-    if ('l' in req.body.options && typeof req.body.options.l == 'number') {
-      reqOptions.push('-l', req.body.options.l);
+    if (allowedOverrides.has('l') && typeof reqOptions.l === 'number') {
+      options.push('-l', reqOptions.l);
     }
   }
 
-  reqOptions.push('-t', nbThreads);
-  reqOptions.push('-x', explorationLevel);
+  if (planMode) {
+    options.push('-c');
+  }
+  if (geometry) {
+    options.push('-g');
+  }
+  options.push('-t', nbThreads);
+  options.push('-x', explorationLevel);
 
   const timestamp = Math.floor(Date.now() / 1000); //eslint-disable-line
   const fileName = path.join(
@@ -216,9 +233,9 @@ function execCallback(req, res) {
     return;
   }
 
-  reqOptions.push('-i', '"' + fileName + '"');
+  options.push('-i', '"' + fileName + '"');
 
-  const vroom = spawn(vroomCommand, reqOptions, {shell: true});
+  const vroom = spawn(vroomCommand, options, {shell: true});
 
   // Handle errors.
   vroom.on('error', err => {


### PR DESCRIPTION
Fixes #110

The override option on the command line changed from `--override` to `-o g -o x -o c -o t -o l ` or the long option `--override g` 
but `--override` without argument still works, it enables all options.
Same for the yml where true enables all options, but it can also be an array with `['c', 'g', 'l', 't', 'x']`.

Additionally paths are now joined with the `path` library which will automatically add slashes where needed. This makes the default option for logdir look less like an absolute path for a linux user.

And thirdly there was a bug when the logdir path contained a space, then the input file would be provided to vroom as multiple arguments. This is fixed by quoting the path when calling `spawn`.